### PR TITLE
Added reddest quality to compositor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OBJ =	src/plcinput.o \
 	src/qualitymethodbase.o \
 	src/linecompositor.o \
 	src/darkestquality.o \
+	src/reddestquality.o \
 	src/greenestquality.o \
 	src/scenemeasurequality.o \
 	src/landsat8cloudquality.o \

--- a/compositor_schema.json
+++ b/compositor_schema.json
@@ -31,7 +31,7 @@
 			"required": true,
 			"enum": ["scene_measure", "darkest", "greenest",
 				 "landsat8", "percentile", "qualityfromfile",
-				 "samesource"]
+				 "samesource", "reddest"]
 		    }
 		}
 	    }

--- a/src/reddestquality.cpp
+++ b/src/reddestquality.cpp
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2014, Planet Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compositor.h"
+
+/************************************************************************/
+/*                             RedQuality                               */
+/************************************************************************/
+
+class RedQuality : public QualityMethodBase 
+{
+    PLCInput *input;
+
+public:
+    RedQuality() : QualityMethodBase("reddest") {}
+    ~RedQuality() {}
+
+    /********************************************************************/
+    QualityMethodBase *create(PLCContext* context, WJElement node) {
+
+        RedQuality *obj = new RedQuality();
+        return obj;
+    }
+
+    /********************************************************************/
+    int computeQuality(PLCInput *input, PLCLine *lineObj) {
+
+        float *quality = lineObj->getNewQuality();
+        int width = lineObj->getWidth();
+
+        if( lineObj->getBandCount() < 3 )
+            CPLError( CE_Fatal, CPLE_AppDefined,
+                      "Reddest Pixel requested without 3 bands." );
+
+        float *red = lineObj->getBand(0);
+        float *green = lineObj->getBand(1);
+        float *blue = lineObj->getBand(2);
+        GByte *alpha = lineObj->getAlpha();
+
+        for(int i=0; i < width; i++ )
+        {
+            if( alpha[i] < 128 )
+                quality[i] = -1.0;
+            else
+                quality[i] = red[i] / ((float) red[i]+green[i]+blue[i]+1);
+        }        
+
+        return TRUE;
+    }
+};
+
+static RedQuality redQualityTemplateInstance;

--- a/tests/small_tests.py
+++ b/tests/small_tests.py
@@ -230,7 +230,34 @@ class Tests(unittest.TestCase):
                            [[255, 255], [255, 255]]])
 
         self.clean_files()
-        
+
+    def test_small_reddest_rgb(self):
+        test_file = self.make_file(TEMPLATE_RGB)
+        args = [
+            '-q',
+            '-s', 'quality', 'reddest',
+            '-o', test_file,
+            '-i',
+            self.make_file(TEMPLATE_RGB,
+                           [[[9, 9], [0, 9]],
+                            [[9, 1], [9, 9]],
+                            [[9, 1], [9, 0]]]),
+            '-i',
+            self.make_file(TEMPLATE_RGB,
+                           [[[9, 8], [6, 6]],
+                            [[0, 8], [6, 5]],
+                            [[0, 8], [6, 5]]]),
+            ]
+
+        self.run_compositor(args)
+
+        self.compare_file(test_file,
+                          [[[9, 9], [6, 9]],
+                           [[0, 1], [6, 9]],
+                           [[0, 1], [6, 0]]])
+
+        self.clean_files()
+
     def test_percentile(self):
         test_file = self.make_file(TEMPLATE_GRAY)
         


### PR DESCRIPTION
This PR adds a "reddest" quality to the compositor in addition to the current "greenest".

In some cases, it would be useful to be able to compose scenes based on "redness" as opposed to only darkness or greenness.  

Cloud shadows tend to shift things towards blue, as well as darken the pixels.  Therefore, a reddest metric will help reduce both clouds and cloud shadows.  Furthermore, preferring redder pixels will help harvested or tilled fields come through preferentially, which can be useful for seasonal mosaics.

One caveat - I've only added a simple test to `small_tests.py`.  In the long run, it would probably be useful to add a new reddest golden image to  `saojose_l8_chip.zip` and update `saojose_tests.py`. 