### PR TITLE
Add support for landsat8 surface reflectance cloud masks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ OBJ =	src/plcinput.o \
 	src/scenemeasurequality.o \
 	src/landsat8cloudquality.o \
 	src/landsat8snowquality.o \
+	src/landsat8cloudquality_sr.o \
 	src/percentilequality.o \
 	src/qualityfromfile.o \
 	src/samesourcequality.o

--- a/compositor_schema.json
+++ b/compositor_schema.json
@@ -31,7 +31,7 @@
 			"required": true,
 			"enum": ["scene_measure", "darkest", "greenest",
 				 "landsat8", "percentile", "qualityfromfile",
-				 "samesource", "landsat8snow"]
+				 "samesource", "landsat8snow", "landsat8sr"]
 		    }
 		}
 	    }

--- a/src/landsat8cloudquality_sr.cpp
+++ b/src/landsat8cloudquality_sr.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2014, Planet Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "compositor.h"
+
+/************************************************************************/
+/*                        Landsat8SRCloudQuality()                      */
+/*                                                                      */
+/*      Compute qualities for this line from the Landsat8 SR quality    */
+/*      mask values.                                                    */
+/************************************************************************/
+
+class Landsat8SRCloudQuality : public QualityMethodBase
+{
+    PLCContext *context;
+    PLCHistogram cloudHistogram;
+
+    float cirrus;
+    float cloud;
+    float shadow;
+    float adjacent;
+    float aerosol;
+    float not_cloud;
+
+public:
+    Landsat8SRCloudQuality() : QualityMethodBase("landsat8sr") {}
+    ~Landsat8SRCloudQuality() {}
+
+    /********************************************************************/
+    QualityMethodBase *create(PLCContext* context, WJElement node) {
+
+        Landsat8SRCloudQuality *obj = new Landsat8SRCloudQuality();
+        obj->context = context;
+        obj->cloudHistogram.counts.resize(6);
+
+        obj->cirrus = -1.0;
+        obj->cloud = -1.0;
+        obj->shadow = 0.33;
+        obj->adjacent = 0.33;
+        obj->aerosol = 0.66;
+        obj->not_cloud = 1.0;
+
+        if( node != NULL )
+        {
+            obj->cirrus =
+                WJEDouble(node, "cirrus", WJE_GET,
+                          obj->cirrus);
+            obj->cloud =
+                WJEDouble(node, "cloud", WJE_GET,
+                          obj->cloud);
+            obj->shadow =
+                WJEDouble(node, "shadow", WJE_GET,
+                          obj->shadow);
+            obj->adjacent =
+                WJEDouble(node, "adjacent", WJE_GET,
+                          obj->adjacent);
+            obj->aerosol =
+                WJEDouble(node, "aerosol", WJE_GET,
+                          obj->aerosol);
+            obj->not_cloud = 
+                WJEDouble(node, "not_cloud", WJE_GET, 
+                          obj->not_cloud);
+
+        }
+
+        return obj;
+    }
+
+    /********************************************************************/
+    int computeQuality(PLCInput *input, PLCLine *lineObj) {
+
+        float *quality = lineObj->getNewQuality();
+        unsigned short *value = lineObj->getCloud();
+        int width = lineObj->getWidth();
+
+        for(int i=0; i < width; i++ )
+        {
+            if ( value[i] & 0x2 ) {
+                quality[i] = cloud;
+            } else {
+                quality[i] = not_cloud;
+            }
+
+            if ( value[i] & 0x1 ) 
+                quality[i] *= cirrus;
+            if ( value[i] & 0x4 ) 
+                quality[i] *= adjacent;
+            if ( value[i] & 0x8 ) 
+                quality[i] *= shadow;
+            if ( (value[i] & 0x10) | (value[i] & 0x20) ) 
+                quality[i] *= aerosol;
+        }
+
+        cloudHistogram.accumulate(quality, width);
+
+        if( context->line == context->height - 1
+            && context->verbose > 0 )
+            cloudHistogram.report(stdout, "L8 SR Cloud Quality");
+        return TRUE;
+    }
+};
+
+static Landsat8SRCloudQuality landsat8SRCloudQualityTemplateInstance;
+


### PR DESCRIPTION
Some Landsat8 surface reluctance products use a different cloud/quality band convention than the standard quality band.  The cloud files for these products are 8-bit data representing a series of bit masks using the following convention:

![image](https://cloud.githubusercontent.com/assets/906803/20410135/4ad92f7c-ace1-11e6-9747-95c3fd1cc785.png)

This PR adds support for these files via the `landsat8sr` quality (as opposed to the usual `landsat8` quality to exclude clouds etc). 

Note that this PR still needs a bit of refinement, but I wanted to get eyes on it relatively early.
cc @kapadia @kjordahl @warmerdam 