### PR TITLE
Ignore dead pixels in the SR cloud mask

### DIFF
--- a/src/landsat8cloudquality_sr.cpp
+++ b/src/landsat8cloudquality_sr.cpp
@@ -88,7 +88,10 @@ public:
 
         for(int i=0; i < width; i++ )
         {
-            if ( value[i] & 0x2 ) {
+            if ( value[i] == 0 ) {
+                // Always skip pixels at edges with nodata cloud values
+                quality[i] = -1.0;
+            } else if ( value[i] & 0x2 ) {
                 quality[i] = cloud;
             } else {
                 quality[i] = not_cloud;


### PR DESCRIPTION
SR cloud mask files sometimes have a smaller extent than their parent landsat scene.  When that occurs, cloudy pixels from the parent scene can leak into the mosaic in the region where there is no overlap between the cloud mask and the scene.

As an example:
![old_sr_cloud_mask](https://cloud.githubusercontent.com/assets/906803/20808865/d151da98-b7c9-11e6-91f3-4de02d9f1941.png)

This PR changes the `landsat8sr` quality to ignore pixels where there are no values in the landsat8 surface reflectance cloud mask.

As an example of the new results:
![new_sr_cloud_mask](https://cloud.githubusercontent.com/assets/906803/20808890/ef585134-b7c9-11e6-8174-049e93387eb8.png)
